### PR TITLE
bugfix/service-status-field-should-not-be-required

### DIFF
--- a/api/app/Http/Requests/ServiceOperationRequest.php
+++ b/api/app/Http/Requests/ServiceOperationRequest.php
@@ -19,7 +19,7 @@ class ServiceOperationRequest extends BaseRequest
             'name' => 'required|string|max:255',
             'description' => 'nullable|string|max:10000',
             'price' => 'required|numeric',
-            'status' => ($this->isMethod('put') || $this->isMethod('patch') ? 'required|' : '') . 'in:' . implode(',', ServiceStatus::values()),
+            'status' => 'in:' . implode(',', ServiceStatus::values()),
         ];
     }
 }


### PR DESCRIPTION
…tion because when creating a data the service is automatically set to available and when updating admin may not to update the status